### PR TITLE
Fix isort.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         - ubuntu
         config:
         # [Python version, tox env]
-        - ["2.7",   "lint"]
+        - ["3.7",   "lint"]
         - ["2.7",   "py27"]
         # Disable coverage until we support Python 3 as coveralls requires this:
         # - ["2.7",   "coverage"]

--- a/.meta.toml
+++ b/.meta.toml
@@ -29,4 +29,6 @@ additional-config = [
     "    src/Products/Formulator/Form.py: E301",
     "    src/Products/Formulator/FormulatorFormFile.py: E301",
     "    src/Products/Formulator/ProductForm.py: E301",
+    "# F821 undefined name (unicode, basestring)",
+    "extend-ignore = F821",
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ per-file-ignores =
     src/Products/Formulator/Form.py: E301
     src/Products/Formulator/FormulatorFormFile.py: E301
     src/Products/Formulator/ProductForm.py: E301
+# F821 undefined name (unicode, basestring)
+extend-ignore = F821
+
 
 [check-manifest]
 ignore =

--- a/src/Products/Formulator/Form.py
+++ b/src/Products/Formulator/Form.py
@@ -9,7 +9,6 @@ from urllib import quote
 import Acquisition
 # Zope
 from AccessControl import ClassSecurityInfo
-from OFS.role import RoleManager
 from Acquisition import aq_base
 from App.class_init import InitializeClass
 from App.Dialogs import MessageDialog
@@ -19,6 +18,7 @@ from OFS.CopySupport import CopyError
 from OFS.CopySupport import eNotSupported
 from OFS.ObjectManager import ObjectManager
 from OFS.PropertyManager import PropertyManager
+from OFS.role import RoleManager
 from OFS.SimpleItem import Item
 from Persistence import Persistent
 # String

--- a/src/Products/Formulator/Validator.py
+++ b/src/Products/Formulator/Validator.py
@@ -6,9 +6,9 @@ from threading import Thread
 from types import StringTypes
 from urllib import urlopen
 
+from AccessControl.tainted import TaintedString
 from DateTime import DateTime
 from urlparse import urljoin
-from AccessControl.tainted import TaintedString
 
 from Products.Formulator import PatternChecker
 from Products.Formulator.DummyField import fields

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
     {envbindir}/test {posargs:-cv}
 
 [testenv:lint]
-basepython = python2.7
+basepython = python3.7
 commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 allowlist_externals =


### PR DESCRIPTION
Python 3 only versions support using directories in the path.

Additionally had to adapt flake8, so it does not break when using Python 3.

Requires #5 to be merged first.