### PR TITLE
Fix test setup so it can run on Zope 2.13.30.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
         # - ["2.7",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
-# Generated from:
+# Initially generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 include *.rst
 include *.txt
+include buildout-base.cfg
 include buildout.cfg
 include buildout213.cfg
 include buildout4.cfg

--- a/buildout-base.cfg
+++ b/buildout-base.cfg
@@ -1,0 +1,22 @@
+# base buildout configuration which does no version pinning at all
+[buildout]
+develop = .
+parts =
+    interpreter
+    test
+extras =
+test_extras = test
+index = https://pypi.org/simple
+allow-picked-versions = true
+show-picked-versions = true
+
+[interpreter]
+recipe = zc.recipe.egg
+interpreter = py
+eggs =
+    Products.Formulator
+
+[test]
+recipe = zc.recipe.testrunner
+eggs =
+    Products.Formulator[${buildout:test_extras}]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,21 +1,4 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
-develop = .
-parts =
-    interpreter
-    test
-extras =
-test_extras = test
-index = https://pypi.org/simple
-
-[interpreter]
-recipe = zc.recipe.egg
-interpreter = py
-eggs =
-    Products.Formulator
-
-[test]
-recipe = zc.recipe.testrunner
-eggs =
-    Products.Formulator[${buildout:test_extras}]
+    buildout-base.cfg

--- a/buildout213.cfg
+++ b/buildout213.cfg
@@ -1,10 +1,6 @@
 [buildout]
 extends =
-    buildout.cfg
     https://zopefoundation.github.io/Zope/releases/2.13.30/versions-prod.cfg
+    buildout-base.cfg
 extras = zope2
 test_extras = zope2, test
-
-
-[versions]
-five.localsitemanager = < 3

--- a/buildout4.cfg
+++ b/buildout4.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    buildout.cfg
     http://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
+    buildout-base.cfg


### PR DESCRIPTION
Using zc.buildout 2.3.x which was used that days.

Before this PR GHA breaks with https://github.com/infrae/Products.Formulator/actions/runs/3168590578/jobs/5159892570