### PR TITLE
We restrict the versions here, as long as we do not support Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ version = '2.0.dev0'
 
 
 tests_require = [
-    'Products.PythonScripts',
+    'Products.PythonScripts < 5.0; python_version=="2.7"',
     'plone.testing',
 ]
 
@@ -47,7 +47,10 @@ setup(name='Products.Formulator',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
+          'grokcore.chameleon < 4.0; python_version=="2.7"',  # transitive
           'grokcore.component',
+          'grokcore.component < 4.0; python_version=="2.7"',
+          'grokcore.view < 4.0; python_version=="2.7"',  # transitive
           'setuptools',
           'zope.component',
           'zope.i18nmessageid',

--- a/src/Products/Formulator/tests/test_serialize.py
+++ b/src/Products/Formulator/tests/test_serialize.py
@@ -331,7 +331,8 @@ class SerializeTestCase(unittest.TestCase):
         request.form['field_float_field'] = '2.71828'
         request.form['subfield_date_field_month'] = '11'
         request.form['subfield_date_field_day'] = '11'
-        request.form['subfield_date_field_year'] = '2022'
+        # This field only allows ten years in the future, today 2023-03-14
+        request.form['subfield_date_field_year'] = '2033'
         request.form['subfield_date_field_hour'] = '09'
         request.form['subfield_date_field_minute'] = '59'
         request.form['field_list_field'] = 'bar'


### PR DESCRIPTION
`zc.buildout` does not respect the `python_requires >= 3.7` in the `setup.py`. As we have no control over `zeam.form` we restrict the transitive dependencies here also for now.