### PR TITLE
Fix HTML quoting for values containing ``"`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix HTML quoting for values containing ``"``.
 
 
 2.0 (2023-03-14)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(name='Products.Formulator',
       zip_safe=False,
       install_requires=[
           'grokcore.chameleon < 4.0; python_version=="2.7"',  # transitive
+          'DocumentTemplate',
+          'DocumentTemplate < 4.0; python_version=="2.7"',
+          'grokcore.component < 4.0; python_version=="2.7"',
           'grokcore.component',
           'grokcore.component < 4.0; python_version=="2.7"',
           'grokcore.view < 4.0; python_version=="2.7"',  # transitive

--- a/src/Products/Formulator/Widget.py
+++ b/src/Products/Formulator/Widget.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2013  Infrae. All rights reserved.
 # See also LICENSE.txt
-import cgi
 import operator
 import string
 
 from DateTime import DateTime
+from DocumentTemplate.html_quote import html_quote
 
 from Products.Formulator.DummyField import fields
 from Products.Formulator.helpers import id_value_re
@@ -249,7 +249,7 @@ class TextAreaWidget(Widget):
               'css_class': css_class,
               'cols': width,
               'rows': height,
-              'contents': cgi.escape(value)}
+              'contents': html_quote(value)}
         if not extra or not id_value_re.search(extra):
             kw['id'] = field.generate_field_html_id(key)
         contents = render_element("textarea", **kw)
@@ -1199,4 +1199,4 @@ def render_value(value, separator=None):
         if not isinstance(separator, unicode):
             separator = unicode(separator, 'utf-8')
         value = separator.join(value)
-    return cgi.escape(render_unicode(value))
+    return html_quote(render_unicode(value))

--- a/src/Products/Formulator/tests/test_widgets.py
+++ b/src/Products/Formulator/tests/test_widgets.py
@@ -47,9 +47,9 @@ class WidgetTestCase(unittest.TestCase):
         self.root.form.manage_addField('text_field', 'Name', 'StringField')
         self.assertEqual(
             self.root.form.text_field.render(
-                value=u"<élèves />"),
+                value=u'<élève"s />'),
             u'<div><input id="field-text-field" name="field_text_field"'
-            u' size="20" type="text" value="&lt;élèves /&gt;" /></div>')
+            u' size="20" type="text" value="&lt;élève&quot;s /&gt;" /></div>')
         self.assertEqual(
             self.root.form.text_field.render_view(value=u"<élèves />"),
             u'&lt;élèves /&gt;')
@@ -74,9 +74,10 @@ class WidgetTestCase(unittest.TestCase):
         self.root.form.manage_addField('life_field', 'Life', 'TextAreaField')
         self.assertEqual(
             self.root.form.life_field.render(
-                value=u"<b>élèves</b>"),
+                value=u'<b>élèv"es"</b>'),
             u'<div><textarea cols="40" id="field-life-field"'
-            u' name="field_life_field" rows="5">&lt;b&gt;élèves&lt;/b&gt;'
+            u' name="field_life_field" rows="5">'
+            u'&lt;b&gt;élèv&quot;es&quot;&lt;/b&gt;'
             u'</textarea></div>')
         self.assertEqual(
             self.root.form.life_field.render_view(value=u"<b>élèves</b>"),


### PR DESCRIPTION
This was changed in https://github.com/infrae/Products.Formulator/commit/7de12470b3f55a429c005f08223da2a1917de859 but double-quotes were no longer quoted from that time on.